### PR TITLE
Refactor/local lygia

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" >
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> <title>Generative Landscapes</title> <link rel="stylesheet" href="style.css" />
     <script src="lib/p5.min.js"></script>
-    <script src="https://lygia.xyz/resolve.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@3.7.3/dist/full.css" rel="stylesheet" type="text/css" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/pixel_sort_shader.frag
+++ b/pixel_sort_shader.frag
@@ -15,8 +15,10 @@ uniform vec2 direction;
 uniform int iFrame;
 
 float hsvbrightness(vec3 c);
+float random(vec3 pos);
 
-#include "lygia/generative/random.glsl"
+#define RANDOM_SCALE vec4(443.897, 441.423, .0973, .1099)
+#define FNC_RANDOM
 
 void main() {
   vec2 uv = vTexCoord;
@@ -88,4 +90,10 @@ float hsvbrightness(vec3 c){
   vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
 
   return q.x;
+}
+
+float random(in vec3 pos) {
+    pos  = fract(pos * RANDOM_SCALE.xyz);
+    pos += dot(pos, pos.zyx + 31.32);
+    return fract((pos.x + pos.y) * pos.z);
 }

--- a/sketch.js
+++ b/sketch.js
@@ -143,8 +143,7 @@ function setup() {
   canvas.pixelDensity(pixel_density);
 
   CaShader = createFilterShader(ca_src.join('\n'));
-  ps_src = resolveLygia(ps_src.join('\n'));
-  PSShader = createFilterShader(ps_src);
+  PSShader = createFilterShader(ps_src.join('\n'));
 
   // Apply the loaded font
   textFont(myFont);


### PR DESCRIPTION
Remove resolveLygia since it's not reliable and lygia page is down more often than expected (may be due to so many reloads when developing I may be the one taking it down)

- Add random method in pixel sorting fragment shader
- Don't resolve lygia in `sketch.js` (not needed anymore)
- Remove lygia import from `index.html`