### PR TITLE
feat: make only toolbar scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 </head>
 <body>
   <script type="module" src="sketch.js"></script>
-    <div class="flex">
-      <div class="w-140" id="toolbar"></div>
+    <div class="flex h-screen">
+      <div class="w-140 overflow-y-auto" id="toolbar"></div>
       <div class="grow h-screen">
         <div id="sketch-container" style="width: 100%; height: 100%;">
           <div id="canvas-wrapper"></div>


### PR DESCRIPTION
- Set a fixed height for the toolbar div.
- Apply overflow-y: auto to the toolbar div.
- Ensure the parent flex container has enough height to accommodate both children.
