### PR TITLE
Feat: audio reactive

### DIFF
--- a/audio_reactive_binds.js
+++ b/audio_reactive_binds.js
@@ -30,6 +30,14 @@ function bind_audio_reactive_controls(){
     });
     disable_ps_passes_per_frame();
 
+    // Centroid
+    // console.log('Binding PS Speed to audio level')
+    // setOnCentroidChange(function(c) {
+    //     var remapedCentroid = map(c, 20, 4000, 30, 2)
+    //     remapedCentroid = constrain(remapedCentroid, 2, 30)
+    //     set_ca_color_change_rate_from_slider(remapedCentroid);
+    // });
+    // disable_ca_color_change_rate();
 
     // Energy Ratio
     console.log('Binding CA Speed to MidHigh/Low energy ratio')
@@ -42,6 +50,37 @@ function bind_audio_reactive_controls(){
         set_ca_passes_per_frame_from_slider(remapedRatio);
     });
     disable_ca_passes_per_frame();
+
+    // HM Energy
+    // // Discarted at the moment, using only the energy level of one band
+    // // ends up being almost the same as using the level of the whole audio.
+    // // better use the ratio between two bands.
+    // setOnHMEnergyChangeCallback(function(energy) {
+    //     // var remapedEnergy = map(e, 0, 25, 30, 2)
+    //     // console.log('remapedEnergy, e', remapedEnergy + ', ' + e)
+    //     // remapedEnergy = constrain(remapedEnergy, 2, 30)
+    //     var new_ppf = 1;
+    //     if (energy > 0.0001 && energy <= 1){
+    //         new_ppf = 0
+    //     }
+    //     else if (energy > 1 && energy <= 10){
+    //         new_ppf = 1
+    //     }
+    //     else if(energy > 10 && energy <= 15){
+    //         new_ppf = 2
+    //     }
+    //     else if(energy > 15 && energy <= 20){
+    //         new_ppf = 3
+    //     }
+    //     else if(energy > 20 && energy <= 30){
+    //         new_ppf = 4
+    //     }
+    //     else if(energy > 40){
+    //         new_ppf = 5
+    //     }
+    //     set_ca_passes_per_frame_from_slider(new_ppf);
+    // });
+    // disable_ca_passes_per_frame();
 
 }
 

--- a/audio_reactive_binds.js
+++ b/audio_reactive_binds.js
@@ -30,6 +30,19 @@ function bind_audio_reactive_controls(){
     });
     disable_ps_passes_per_frame();
 
+
+    // Energy Ratio
+    console.log('Binding CA Speed to MidHigh/Low energy ratio')
+    setOnEnergyRatioChangeCallback(function(energyRatio) {
+        var remapedRatio = map(energyRatio, 0, 0.3, 0, 5)
+        remapedRatio = parseInt(constrain(remapedRatio, 0, 5))
+        if (energyRatio<=0.1){ // To generate some CA movement without any audio
+            remapedRatio = 1
+        }
+        set_ca_passes_per_frame_from_slider(remapedRatio);
+    });
+    disable_ca_passes_per_frame();
+
 }
 
 

--- a/audio_reactive_binds.js
+++ b/audio_reactive_binds.js
@@ -1,0 +1,15 @@
+import {change_ps_direction, disable_ps_direction_change_rate, set_ps_direction_change_rate_from_slider, set_ps_passes_per_frame_from_slider, disable_ps_passes_per_frame} from './lib/JSGenerativeArtTools/pixel_sort.js'
+import {set_ca_passes_per_frame_from_slider, disable_ca_passes_per_frame} from './lib/JSGenerativeArtTools/cellular_automata.js'
+import {level_scale, level_min_value, level_max_value, setOnBeatCallback, setOnLevelChangeCallback, setOnEnergyRatioChangeCallback} from './lib/JSGenerativeArtTools/audio/audio_reactive.js'
+
+var ps_speed_min_value = 2;
+var ps_speed_max_value = 23;
+
+function bind_audio_reactive_controls(){
+    console.log('Binding audio reactive controls')
+}
+
+
+export {
+    bind_audio_reactive_controls,
+}

--- a/audio_reactive_binds.js
+++ b/audio_reactive_binds.js
@@ -7,6 +7,14 @@ var ps_speed_max_value = 23;
 
 function bind_audio_reactive_controls(){
     console.log('Binding audio reactive controls')
+
+    // Beat Detect
+    console.log('Binding PS Direction to Beat Detection')
+    setOnBeatCallback(function() {
+        change_ps_direction();
+    });
+    set_ps_direction_change_rate_from_slider(0);
+    disable_ps_direction_change_rate();
 }
 
 

--- a/audio_reactive_binds.js
+++ b/audio_reactive_binds.js
@@ -15,6 +15,21 @@ function bind_audio_reactive_controls(){
     });
     set_ps_direction_change_rate_from_slider(0);
     disable_ps_direction_change_rate();
+
+    // Audio Level
+    console.log('Binding PS Speed to audio level')
+    setOnLevelChangeCallback(function(e) {
+        var scaled_level = level_scale * e;
+        var remapedForLog = map(scaled_level, level_min_value, level_max_value, 1, 2.8)
+        remapedForLog = constrain(remapedForLog, 1, 2.8)
+
+        var remapedLevel = map(log(remapedForLog), 0, 1, ps_speed_min_value, ps_speed_max_value)
+        remapedLevel = pow(remapedLevel, 1.3)
+        remapedLevel = constrain(remapedLevel, ps_speed_min_value, ps_speed_max_value)
+        set_ps_passes_per_frame_from_slider(remapedLevel);
+    });
+    disable_ps_passes_per_frame();
+
 }
 
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" >
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> <title>Generative Landscapes</title> <link rel="stylesheet" href="style.css" />
     <script src="lib/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/addons/p5.sound.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@3.7.3/dist/full.css" rel="stylesheet" type="text/css" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/sketch.js
+++ b/sketch.js
@@ -5,6 +5,7 @@ import {scaleCanvasToFit, prepareP5Js} from './lib/JSGenerativeArtTools/utils.js
 import {calculateFPS, displayFPS} from './lib/JSGenerativeArtTools/fps.js';
 import {intialize_toolbar} from './toolbar.js';
 import {initializeAudio, getEnergyRatio, getHMEnergy, getSpectrum, getAudioLevel, detectBeat} from './lib/JSGenerativeArtTools/audio/audio_reactive.js'
+import {bind_audio_reactive_controls} from './audio_reactive_binds.js'
 
 // The desired artwork size in which everything is pixel perfect.
 // Let the canvas resize itself to fit the screen in "scaleCanvasToFit()" function.
@@ -112,6 +113,10 @@ function setup() {
   initialize_cellular_automata_shader()
   initialize_pixel_sorting_shader()
 
+  // Bind Audio Reactive Methods
+  initializeAudio();
+  bind_audio_reactive_controls();
+
   // Apply the loaded font
   textFont(myFont);
 
@@ -121,6 +126,8 @@ function setup() {
 }
 
 function draw() {
+  run_audio_analysis();
+
   if (image_loaded_successfuly){
     draw_steps()
   }

--- a/sketch.js
+++ b/sketch.js
@@ -4,6 +4,7 @@ import {load_cellular_automata_code, set_ca_max_steps, reset_ca_steps, get_Cellu
 import {scaleCanvasToFit, prepareP5Js} from './lib/JSGenerativeArtTools/utils.js';
 import {calculateFPS, displayFPS} from './lib/JSGenerativeArtTools/fps.js';
 import {intialize_toolbar} from './toolbar.js';
+import {initializeAudio, getEnergyRatio, getHMEnergy, getSpectrum, getAudioLevel, detectBeat} from './lib/JSGenerativeArtTools/audio/audio_reactive.js'
 
 // The desired artwork size in which everything is pixel perfect.
 // Let the canvas resize itself to fit the screen in "scaleCanvasToFit()" function.
@@ -205,6 +206,14 @@ function initializeCanvas(input_image){
 
   scaleCanvasToFit(canvas, artworkHeight, artworkWidth);
 
+}
+
+function run_audio_analysis(){
+  var audioLevel = getAudioLevel()
+  getSpectrum()
+  getHMEnergy()
+  getEnergyRatio()
+  detectBeat(audioLevel)
 }
 
 function windowResized() {


### PR DESCRIPTION
- Create `audio_reactive_binds` module to generate bindings between audio changes and module parametters
    - Audio level to PS Passes per frame
    - Low / MidHigh energy ratio to CA Passes per frame
    - Beat detection to PS direction change
- Create `run_audio_analisis()`methon in `sketch.js` to call every draw call
- Initialize audio and call `audio_reactive_binds` from setup