### PR TITLE
fix: only initialize inside updateArtworkSeed() when applyUIChanges

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -241,7 +241,6 @@ export function applyUIChanges(){
   
   // Redraw everything
   updateArtworkSeed()
-  initializeCanvas()
 }
 
 function updateArtworkSettings() {


### PR DESCRIPTION
Double execution of `initializeCanvas()` on `applyUIChanges()` causes trouble when a user image is being used.
It runs two times and only loads the image once, somehow the image is lost in the process and fails